### PR TITLE
finish hw08

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 # 如果需要指定显卡版本号的话：
-# set(CMAKE_CUDA_ARCHITECTURES 52)
+set(CMAKE_CUDA_ARCHITECTURES 75)
 
 project(hellocmake LANGUAGES CXX CUDA)
 

--- a/main.cu
+++ b/main.cu
@@ -30,7 +30,7 @@ int main() {
     std::vector<int, CudaAllocator<int>> counter(1);
 
     // fill_sin 改成“网格跨步循环”以后，这里三重尖括号里的参数如何调整？10 分
-    fill_sin<<<n / 1024, 1024>>>(arr.data(), n);
+    fill_sin<<<1, 1024>>>(arr.data(), n);
 
     // 这里的“边角料法”对于不是 1024 整数倍的 n 会出错，为什么？请修复：10 分
     filter_positive<<<(n+1023) / 1024, 1024>>>(counter.data(), res.data(), arr.data(), n);


### PR DESCRIPTION
1.这是基于“边角料法”的，请把他改成基于“网格跨步循环”的：
应用于线程和板块一起上的情况，可以匹配任意板块和线程数量。
2.这里有什么问题？请改正：
+=操作会导致线程冲突，因此改用原子加。
3.改成“网格跨步循环”以后，这里三重尖括号里的参数如何调整？：
将板块数改为1，每个线程处理n/1024个元素。
4.这里的“边角料法”对于不是 1024 整数倍的 n 会出错，为什么？：
除法向下取整，因此最后不满blockdim的数据无法被处理。板块数量改为（n+ blockdim -1）/ blockdim即可
5.这里 CPU 访问数据前漏了一步什么操作？：
当前时刻线程未全部执行完成，因此需要做一次同步。