### PR TITLE
hw08 GeLee

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,16 @@ set(CMAKE_CUDA_STANDARD 17)
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
+
+#set(CMAKE_CUDA_SEPARABLE_COMPILATION ON)
 # 如果需要指定显卡版本号的话：
-# set(CMAKE_CUDA_ARCHITECTURES 52)
+set(CMAKE_CUDA_ARCHITECTURES 75)
 
 project(hellocmake LANGUAGES CXX CUDA)
 
 add_executable(main main.cu)
+#add_executable(main test.cu)
+set_property(TARGET main PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+
 target_include_directories(main PUBLIC include)
+target_compile_options(main PUBLIC $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>)

--- a/include/CudaAllocator.h
+++ b/include/CudaAllocator.h
@@ -9,6 +9,17 @@ template <class T>
 struct CudaAllocator {
     using value_type = T;
 
+    CudaAllocator() noexcept {};
+    template<class U> CudaAllocator(const CudaAllocator<U>&) noexcept {}
+    template<class U> bool operator==(const CudaAllocator<U>&) const noexcept
+    {
+        return true;
+    }
+    template<class U> bool operator!=(const CudaAllocator<U>&) const noexcept
+    {
+        return false;
+    }
+
     T *allocate(size_t size) {
         T *ptr = nullptr;
         checkCudaErrors(cudaMallocManaged(&ptr, size * sizeof(T)));

--- a/main.cu
+++ b/main.cu
@@ -4,25 +4,33 @@
 #include "helper_cuda.h"
 #include <cmath>
 #include <vector>
-// #include <thrust/device_vector.h>  // 如果想用 thrust 也是没问题的
+ #include <thrust/device_vector.h>  // 如果想用 thrust 也是没问题的
+
+
 
 // 这是基于“边角料法”的，请把他改成基于“网格跨步循环”的：10 分
-__global__ void fill_sin(int *arr, int n) {
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < n) return;
-    arr[i] = sinf(i);
-}
-
-__global__ void filter_positive(int *counter, int *res, int const *arr, int n) {
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < n) return;
-    if (arr[i] >= 0) {
-        // 这里有什么问题？请改正：10 分
-        int loc = *counter;
-        *counter += 1;
-        res[loc] = n;
+template<class Func>
+__global__ void parallel_for(int n, Func func){
+    for(int i = blockDim.x * blockIdx.x + threadIdx.x;
+        i < n ; i += blockDim.x * gridDim.x){
+        func(i);
     }
 }
+
+
+//原方法问题，多线程对同时读取/修改/写回counter;
+//采取原子操作解决；
+
+__global__ void filter_positive(int *counter, int *res, int const *arr, int n){
+    for(int i = blockDim.x * blockIdx.x + threadIdx.x;
+        i < n ; i += blockDim.x * gridDim.x){
+        if(arr[i] >= 0 ){
+            int loc = atomicAdd(counter,1);
+            res[loc] = n;
+        }
+    }
+}
+
 
 int main() {
     constexpr int n = 1<<24;
@@ -31,17 +39,24 @@ int main() {
     std::vector<int, CudaAllocator<int>> counter(1);
 
     // fill_sin 改成“网格跨步循环”以后，这里三重尖括号里的参数如何调整？10 分
-    fill_sin<<<n / 1024, 1024>>>(arr.data(), n);
-
+    parallel_for<<<32,1014>>>(n,[arr_data = arr.data()] __device__ (int i ){
+        arr_data[i] = sinf(i);
+    });
+    
     // 这里的“边角料法”对于不是 1024 整数倍的 n 会出错，为什么？请修复：10 分
-    filter_positive<<<n / 1024, 1024>>>(counter.data(), res.data(), arr.data(), n);
+    //原因：如果不是整数倍，就会漏掉最后几个元素；既可以采用向上取整，也可以网格跨步循环来解决；
+    filter_positive<<<32,1024>>>(counter.data(), res.data(), arr.data(), n);
+
 
     // 这里 CPU 访问数据前漏了一步什么操作？请补上：10 分
+    //调用 cudaDeviceSynchronize()，让 CPU 陷入等待，等 GPU 完成队列的所有任务后再返回。
+    checkCudaErrors(cudaDeviceSynchronize());
 
     if (counter[0] <= n / 50) {
         printf("Result too short! %d <= %d\n", counter[0], n / 50);
         return -1;
     }
+
     for (int i = 0; i < counter[0]; i++) {
         if (res[i] < 0) {
             printf("Wrong At %d: %f < 0\n", i, res[i]);


### PR DESCRIPTION
## 作业解释

> fill_sin 改成“网格跨步循环”以后，这里三重尖括号里的参数如何调整？10 分

**解决方法**：

- 采取网格跨步循环，`gridDim` 改为32即可。
- 将相关函数改为模板函数；采取`lambda`表达式来当函子。



> 这里的“边角料法”对于不是 1024 整数倍的 n 会出错，为什么？请修复：10 分

**原因：**

- 如果不是整数倍，就会漏掉最后几个元素；

**方法：**

- 既可以采用向上取整，
- 也可以网格跨步循环来解决；



>  这里 CPU 访问数据前漏了一步什么操作？请补上：10 分

调用 `cudaDeviceSynchronize()`，让 CPU 陷入等待，等 GPU 完成队列的所有任务后再返回。



## 所遇到困难

- MSVC bug

> `CudaAllocator.h` 在编译期间会报错

` error: no suitable user-defined conversion from "std::_Rebind_alloc_t<CudaAllocator<int>, int>" to "std::_Rebind_alloc_t<std::_Rebind_alloc_t<CudaAllocator<int>, int>`

查询文档：

https://docs.microsoft.com/zh-cn/cpp/standard-library/allocators?view=msvc-170

在头文件中增加如下内容即可。

```
	CudaAllocator() noexcept {};
    template<class U> CudaAllocator(const CudaAllocator<U>&) noexcept {}
    template<class U> bool operator==(const CudaAllocator<U>&) const noexcept
    {
        return true;
    }
    template<class U> bool operator!=(const CudaAllocator<U>&) const noexcept
    {
        return false;
    }
```

