### PR TITLE
hw08/cuda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 # 如果需要指定显卡版本号的话：
-# set(CMAKE_CUDA_ARCHITECTURES 52)
+set(CMAKE_CUDA_ARCHITECTURES 70)
 
 project(hellocmake LANGUAGES CXX CUDA)
 


### PR DESCRIPTION
（迟来的Pr...）
* `filter_positive()`有什么问题?
  在一个线程中对counter+1时，可能会有另外一个线程同时取出counter的旧值+1，而不是最新值，因此造成错误。使用`atomicAdd()`原子操作避免上述问题
* `fill_sin`改为网格跨步循环后，可以指定任意的线程数（blockDim）和板块数（gridDim），无需担心越界或漏元素的问题
* “边角料法”对于不是 1024 整数倍的 n 会出错，为什么？
若n = 1025，n / 1024 = 1，总共会启动1*1024=1024个线程，会漏掉1个元素
* CPU访问数据遗漏了同步，同步可以让CPU陷入等待，等GPU中的任务队列执行完毕后才继续工作
