### PR TITLE
小彭老师《c++中的高性能并行编程与优化》的第8讲作业

### DIFF
--- a/include/CudaAllocator.h
+++ b/include/CudaAllocator.h
@@ -9,6 +9,8 @@ template <class T>
 struct CudaAllocator {
     using value_type = T;
 
+    constexpr CudaAllocator() noexcept {}   // BugFix
+
     T *allocate(size_t size) {
         T *ptr = nullptr;
         checkCudaErrors(cudaMallocManaged(&ptr, size * sizeof(T)));

--- a/main.cu
+++ b/main.cu
@@ -4,39 +4,42 @@
 #include "helper_cuda.h"
 #include <cmath>
 #include <vector>
-// #include <thrust/device_vector.h>  // 如果想用 thrust 也是没问题的
 
-// 这是基于“边角料法”的，请把他改成基于“网格跨步循环”的：10 分
-__global__ void fill_sin(int *arr, int n) {
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < n) return;
-    arr[i] = sinf(i);
+// 改为网格跨步循环（Grid-stride loop）
+// 数组类型改为 float，因为 sinf 返回的是浮点数
+__global__ void fill_sin(float *arr, int n) {
+    for (int i = blockIdx.x * blockDim.x + threadIdx.x;
+         i < n;
+         i += blockDim.x * gridDim.x) {
+        arr[i] = sinf(i);
+    }
 }
 
-__global__ void filter_positive(int *counter, int *res, int const *arr, int n) {
+// 使用 atomicAdd 解决竞态条件
+__global__ void filter_positive(int *counter, float *res, float const *arr, int n) {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i < n) return;
+    if (i >= n) return;           // 修复：>= 而不是 
     if (arr[i] >= 0) {
-        // 这里有什么问题？请改正：10 分
-        int loc = *counter;
-        *counter += 1;
-        res[loc] = n;
+        int loc = atomicAdd(counter, 1);  // 原子操作，保证线程安全
+        res[loc] = arr[i];                // 修复：存 arr[i] 而不是 n
     }
 }
 
 int main() {
-    constexpr int n = 1<<24;
-    std::vector<int, CudaAllocator<int>> arr(n);
-    std::vector<int, CudaAllocator<int>> res(n);
-    std::vector<int, CudaAllocator<int>> counter(1);
+    constexpr int n = 1 << 24;
+    std::vector<float, CudaAllocator<float>> arr(n);
+    std::vector<float, CudaAllocator<float>> res(n);
+    std::vector<int, CudaAllocator<int>> counter(1, 0);  // 初始化为 0
 
-    // fill_sin 改成“网格跨步循环”以后，这里三重尖括号里的参数如何调整？10 分
-    fill_sin<<<n / 1024, 1024>>>(arr.data(), n);
+    // 网格跨步循环后，参数不再必须是 n/1024
+    // 32 个 block，每块 128 线程，每线程循环处理多个元素
+    fill_sin<<<32, 128>>>(arr.data(), n);
 
-    // 这里的“边角料法”对于不是 1024 整数倍的 n 会出错，为什么？请修复：10 分
-    filter_positive<<<n / 1024, 1024>>>(counter.data(), res.data(), arr.data(), n);
+    // 修复：用 ceil 除法保证覆盖所有元素（边角料问题）
+    filter_positive<<<(n + 1023) / 1024, 1024>>>(counter.data(), res.data(), arr.data(), n);
 
-    // 这里 CPU 访问数据前漏了一步什么操作？请补上：10 分
+    // 修复：CPU 访问前必须同步
+    checkCudaErrors(cudaDeviceSynchronize());
 
     if (counter[0] <= n / 50) {
         printf("Result too short! %d <= %d\n", counter[0], n / 50);
@@ -45,10 +48,10 @@ int main() {
     for (int i = 0; i < counter[0]; i++) {
         if (res[i] < 0) {
             printf("Wrong At %d: %f < 0\n", i, res[i]);
-            return -1;  // 突然想起了ICPC有一年队名叫“蓝翔WA掘机”的，笑不活了:)
+            return -1;
         }
     }
 
-    printf("All Correct!\n");  // 还有个队名叫“AC自动机”的，和隔壁“WAWA大哭”对标是吧:)
+    printf("All Correct!\n");
     return 0;
 }


### PR DESCRIPTION
## 修复内容

1. **fill_sin 逻辑错误**：`if (i < n) return` 条件写反了，改为 `if (i >= n) return`。

2. **改为网格跨步循环**：将 fill_sin 改为 grid-stride loop，
   启动参数从 `n/1024` 个 block 改为固定的少量 block，
   每个线程通过循环处理多个元素，更灵活也更高效。

3. **类型错误**：sinf() 返回 float，原来存入 int 数组会截断为 0，
   将 arr 和 res 的类型改为 float。

4. **竞态条件（Race Condition）**：多个 GPU 线程同时执行
   `int loc = *counter; *counter += 1` 会导致数据竞争，
   改用 atomicAdd 保证原子性。

5. **边角料法截断**：`n / 1024` 在 n 不是 1024 整数倍时会丢失末尾元素，
   改为 `(n + 1023) / 1024` 向上取整。

6. **缺少 CPU-GPU 同步**：GPU 核函数异步执行，CPU 读取结果前必须调用
   cudaDeviceSynchronize() 等待完成。

7. **CudaAllocator 缺少默认构造函数**：STL 容器要求 allocator 可默认构造，
   补充了 `constexpr CudaAllocator() noexcept {}`。

## 测试结果
All Correct!